### PR TITLE
add symlinking of plugins to Fusiondirectory

### DIFF
--- a/src/FusionDirectory/Tools/Setup.php
+++ b/src/FusionDirectory/Tools/Setup.php
@@ -602,7 +602,7 @@ class Setup extends Cli\LdapApplication
   protected function getClassesList (string $path): array
   {
     /* Recursive iterator on the directory */
-    $Directory = new \RecursiveDirectoryIterator($path, \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_PATHNAME);
+    $Directory = new \RecursiveDirectoryIterator($path, \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::FOLLOW_SYMLINKS);
     /* Flatten the iterator to iterate directly on all files in the tree */
     $Iterator = new \RecursiveIteratorIterator($Directory);
     /* Filter by regex */


### PR DESCRIPTION
adding option to symlink plugin files to FusionDirectory instead of copying.
This allows plugin development in fusiondirectory-plugins working tree.  